### PR TITLE
add /usr/local/bin to PATH env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $script = <<SCRIPT
+export PATH=$PATH:/usr/local/bin
 cd /tmp
 
 # Set time


### PR DESCRIPTION
Hi, It seems that `/usr/bin/env` cannot find ruby in `/usr/local/bin` because script is executed as `root`.
