### PR TITLE
fix: chomp last newline chars when get port number from system call

### DIFF
--- a/handlers/hook.rb
+++ b/handlers/hook.rb
@@ -102,7 +102,7 @@ end
 def get_port_of_container(container_id)
   Apache.errlogger Apache::APLOG_NOTICE, \
     "Getting port id for container<#{container_id}>"
-  `docker inspect --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' #{container_id}`
+  `docker inspect --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' #{container_id}`.chomp
 end
 
 #


### PR DESCRIPTION
This fix for preventing errors below;

```
[Mon Aug 11 07:08:18 2014] [error] [client 192.168.20.1] proxy: DNS lookup failure for: localhost:49153\n returned by /
```

Actually, the system call returns value include "\n" at last chars. it must be removed.
