### PR TITLE
Fix not found error when users access expected urls

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,10 @@ usermod -G docker apache
 # Add supervisor configuration file
 cp /app/provisioning/supervisord.conf /etc/supervisord.conf
 
+# Add misc direcotries and file to launch hook script
+mkdir -p /app/images
+touch /app/images/ids
+
 # Add log directories
 mkdir -p /var/log/supervisor
 mkdir -p /var/log/builder


### PR DESCRIPTION
In my environment, when i access the url for the sample web application (http://c8f48c60088bbae0d0fb25ed5fd04f4442b58617.pool.dev/ ), browser (Chrome)  returns Not Found error (404).

In the vagrant instance i found the following errors in  /var/log/httpd/error_log. 

```
[Fri Sep 05 08:46:43 2014] [notice] AH05003: mod_mruby mod_mruby_init: mod_mruby / 1.4.1 mechanism enabled.
[Fri Sep 05 08:46:43 2014] [notice] Digest: generating secret for digest authentication ...
[Fri Sep 05 08:46:43 2014] [notice] Digest: done
[Fri Sep 05 08:46:43 2014] [notice] AH05003: mod_mruby mod_mruby_init: mod_mruby / 1.4.1 mechanism enabled.
[Fri Sep 05 08:46:43 2014] [notice] Apache/2.2.15 (Unix) DAV/2 configured -- resuming normal operations mkdir: cannot create directory `/app/images': Permission denied
[Fri Sep 05 08:58:11 2014] [error] mod_mruby ERROR ap_mrb_raise_error: mrb_run failed: [TYPE: FILE] [CACHED: DISABLE] mruby raise: /app/handlers/hook.rb:60: Could not open file (/app/images/ids) (File::FileError)
[Fri Sep 05 08:58:11 2014] [error] [client 192.168.20.1] File does not exist: (null) mkdir: cannot create directory `/app/images': Permission denied
[Fri Sep 05 08:58:14 2014] [error] mod_mruby ERROR ap_mrb_raise_error: mrb_run failed: [TYPE: FILE]    [CACHED: DISABLE] mruby raise: /app/handlers/hook.rb:60: Could not open file (/app/images/ids)(File::FileError)
[Fri Sep 05 08:58:14 2014] [error] [client 192.168.20.1] File does not exist: (null) mkdir: cannot create directory `/app/images': Permission denied
```

This patch fixes the not found error adding a /app/images directory and /app/ids file in the vagrant image.
