### PR TITLE
scripts: util scripts for development

### DIFF
--- a/scripts/clear_containers
+++ b/scripts/clear_containers
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker kill $(docker ps -a -q)
+docker rm $(docker ps -a -q)

--- a/scripts/rebuild_build_server
+++ b/scripts/rebuild_build_server
@@ -1,0 +1,31 @@
+#!/bin/sh
+OPTIND=1 
+
+start=false
+
+while getopts "s" opt; do
+    case "$opt" in
+    s)  start=true
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+docker kill pool 2>&1 > /dev/null
+docker rm pool 2>&1 > /dev/null
+cd /app/docker/pool
+docker build -t pool-server .
+
+if [ $start == "true" ]; then
+     docker run -d -v /var/run/docker.sock:/var/run/docker.sock \
+          --name pool -p 80:80 -p 8080:8080 pool-server
+else
+     echo -e "please run manually: 
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name pool -p 80:80 -p 8080:8080 pool-server
+or
+docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock --name pool -p 80:80 -p 8080:8080 pool-server /bin/bash
+"
+fi
+
+


### PR DESCRIPTION
I'd like to add some util scripts for developing pool.
- `clear_containers`
  - Kill & remove all running containers
- `rebuild_build_servers`
  - Rebuild the image of build server. If `-s` option is enabled, running the image after rebuilding.
