### PR TITLE
Use cached base image of build server if it exists

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,12 @@ PREVIEW_REPOSITORY_URL=$1
 export PATH=$PATH:/usr/local/bin
 cd /tmp
 
+# load cache images on local if it exists (for speed to build vagrant)
+IMAGE_APACHE_MOD_MRUBY="/app/images/apache-mod-mruby.tar"
+if [[ -f  ${IMAGE_APACHE_MOD_MRUBY} ]]; then
+    sudo docker load < ${IMAGE_APACHE_MOD_MRUBY} 
+fi
+
 # build build-server
 cd /app/docker/pool
 docker build -t pool-server .


### PR DESCRIPTION
For speed to `vagrant up` , use [image cache](https://github.com/ainoya/docker-apache-mod_mruby/releases) on local disk.
