### PR TITLE
add mantainance script, docker-enter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /images
 dns.log
 
-*/**/vendor
+vendor/*
 */**/out
 .bundle
 *.lock

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,11 @@ if [[ -f  ${IMAGE_APACHE_MOD_MRUBY} ]]; then
     sudo docker load < ${IMAGE_APACHE_MOD_MRUBY} 
 fi
 
+# Add mantainance script to log in to docker
+mkdir -p /app/vendor/scripts
+wget -q https://raw.githubusercontent.com/jpetazzo/nsenter/master/docker-enter -O /app/vendor/scripts/docker-enter
+chmod +x /app/vendor/scripts/docker-enter
+
 # build build-server
 cd /app/docker/pool
 docker build -t pool-server .


### PR DESCRIPTION
Import useful scritp from https://github.com/jpetazzo/nsenter .
Now you can use,

```
➜  pool git:(add-docker-enter-script) ✗ vagrant ssh
CoreOS (alpha)
core@pool ~ $ sudo /app/vendor/scripts/docker-enter pool
# enter the container
bash-4.1# 
```
