### PR TITLE
pool-server: sustain tail when apache log file was rotated

### DIFF
--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -52,5 +52,5 @@ EXPOSE 80 8080
 
 CMD \
     /app/scripts/starter && \
-    tailf /var/log/httpd/error_log
+    tail -F /var/log/httpd/error_log
 


### PR DESCRIPTION
Stop pool-server container to commit suicide because when apache log is rotated by a hour.

> Use the -F option instead:  tail -F /var/log/kern.log The -F option tells tail to track changes to the file by filename, instead of using the inode number which changes during rotation. It will also keep trying to open the file if it's not present. 

ref: http://unix.stackexchange.com/questions/22698/how-to-do-a-tail-f-of-log-rotated-files
