### PR TITLE
reverse_proxy requires r.uri as uri path

### DIFF
--- a/docker/pool/handlers/hook.rb
+++ b/docker/pool/handlers/hook.rb
@@ -80,6 +80,6 @@ else
   addr = get_addr_of_container(container_id)
   port = get_port_of_container(container_id)
   r = Apache::Request.new()
-  r.reverse_proxy "http://#{addr}:#{port}" + r.unparsed_uri
+  r.reverse_proxy "http://#{addr}:#{port}" + r.uri
   Apache::return(Apache::OK)
 end


### PR DESCRIPTION
This PR fixes the issue #58 .
`unparsed_uri` with query string with `?` character is encoded to `%3F` in `r.reverse_proxy`(`r.filename`). and query string is added to `r` object in background as `s.args`.  
