### PR TITLE
Builder: strip control chars (include codes/colors) of build log

### DIFF
--- a/docker/pool/builder/lib/builder/builder_log_device.rb
+++ b/docker/pool/builder/lib/builder/builder_log_device.rb
@@ -17,7 +17,7 @@ module Builder
     # write and send to client the log message
     def write(message)
       @logfile.write(message) unless @logfile.nil?
-      @ws.send(strip_ansi_color(message))
+      @ws.send(strip_control_chars(message))
     end
 
     # Close file object
@@ -25,8 +25,8 @@ module Builder
       @logfile.close
     end
 
-    def strip_ansi_color(message)
-      message.gsub(/\e\[[^m]*m/, '')
+    def strip_control_chars(message)
+      message.gsub(/\x1B\[[0-9;]*[a-zA-Z]/, '')
     end
   end
 end

--- a/docker/pool/builder/spec/builder/builder/builder_log_device_spec.rb
+++ b/docker/pool/builder/spec/builder/builder/builder_log_device_spec.rb
@@ -1,0 +1,20 @@
+$LOAD_PATH.unshift File.expand_path('../', __FILE__)
+require 'spec_helper'
+
+require 'builder/builder_log_device'
+
+describe Builder::BuilderLogDevice.new("dummy ws") do
+    it 'strip control chars' do
+        normal_chars = "blah blah blah"
+        actual = subject.strip_control_chars("\x1B[0A\x1B[2K#{normal_chars}\x1B[0B")
+
+        expect(actual).to eq(normal_chars)
+    end
+
+    it 'strip color code' do
+        normal_chars = "blah blah blah"
+        actual = subject.strip_control_chars("\x1B[255;255;255m#{normal_chars}\x1B[0m")
+
+        expect(actual).to eq(normal_chars)
+    end
+end


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/2300438/5156663/75e7fdd6-731a-11e4-900c-bfe353d49fdb.png)

After:
![image](https://cloud.githubusercontent.com/assets/2300438/5156666/94752206-731a-11e4-8b89-1d6176177f4d.png)

Actual terminal output:

execute below command:

```
python -c "print('\n'.join([(' '.join([('tr((i + j)) + 'm' + str((i + j)).ljust(5) + '') if i + j < 256 else '' for j in range(10)])) for i in range(0, 256, 10)]))"
```

![image](https://cloud.githubusercontent.com/assets/2300438/5156665/8affb3d0-731a-11e4-97ec-7da868cce1e1.png)
