### PR TITLE
build-screen: use document.location.hostname instead of document.location.host

### DIFF
--- a/docker/pool/build-screen/app/scripts/main.js
+++ b/docker/pool/build-screen/app/scripts/main.js
@@ -1,7 +1,7 @@
 (function () {
     showCommitId();
 
-    var ws = new WebSocket("ws://" + document.location.host + ":8080");
+    var ws = new WebSocket("ws://" + document.location.hostname + ":8080");
     ws.onmessage = function(event){
         if (event.data.match(/FINISHED$/)) {
             document.location.reload();


### PR DESCRIPTION
In the case of the address is `http://localhost:9000`, 
`"ws://" + document.location.hostname + ":8080")` become `http://localhost:9000:8080` because `document.location.host` returns `localhost:9000`.
