### PR TITLE
Fix to resolve remotes branch correctly

### DIFF
--- a/docker/pool/builder/bin/build_server
+++ b/docker/pool/builder/bin/build_server
@@ -2,25 +2,17 @@
 # -*- mode: ruby -*-
 
 require 'em-websocket'
-require 'git'
-require 'pty'
-
 require 'builder'
-
-WORK_DIR = "/app/images"
-APP_REPO_DIR = "#{WORK_DIR}/app_repo"
 
 EM.run {
   EM::WebSocket.run(:host => '0.0.0.0', :port => 8080) do |ws|
     ws.onopen { |handshake|
       puts 'WebSocket connection open'
       target = handshake.headers['Host'].split('.')[0]
-      git = Git::open(APP_REPO_DIR)
-      @git_commit_id = git.revparse(target)
 
       Thread.new(ws) do |ws|
         begin
-          builder = Builder::Builder.new(ws, @git_commit_id)
+          builder = Builder::Builder.new(ws, target)
           builder.up
         rescue => ex
           puts "#{ex.class}: #{ex.message}; #{ex.backtrace}"
@@ -36,4 +28,8 @@ EM.run {
       ws.send "Pong: #{msg}"
     }
   end
+  
+  # GET "http://0.0.0.0:9000/resolve_git_commit/origin/development",
+  # then it responses commit-id of "origin/development"
+  EM::start_server("0.0.0.0", 9000, Builder::GitHandler)
 }

--- a/docker/pool/builder/builder.gemspec
+++ b/docker/pool/builder/builder.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "em-websocket"
+  spec.add_runtime_dependency "eventmachine_httpserver"
   spec.add_runtime_dependency "git"
 
   spec.add_development_dependency "bundler"

--- a/docker/pool/builder/lib/builder/git_handler.rb
+++ b/docker/pool/builder/lib/builder/git_handler.rb
@@ -1,0 +1,25 @@
+require 'eventmachine'
+require 'evma_httpserver'
+
+module Builder
+  class GitHandler < EventMachine::Connection
+    include EventMachine::HttpServer
+    include Builder
+   
+    def process_http_request
+      res = EventMachine::DelegatedHttpResponse.new(self)
+
+      if @http_path_info =~ /^\/resolve_git_commit\/(.*)$/
+        res.status = 200
+        begin
+          res.content = resolve_commit_id($1)
+        rescue => e
+          res.content = e
+        end
+      end
+
+      res.status  = 500
+      res.send_response
+    end
+  end
+end

--- a/docker/pool/handlers/hook.rb
+++ b/docker/pool/handlers/hook.rb
@@ -101,7 +101,7 @@ unless FileTest.exist?(APP_REPO_DIR)
     unless FileTest.exist?(APP_REPO_DIR)
 end
 
-target_commit_id = `git --git-dir=#{APP_REPO_DIR}/.git rev-parse #{target}`.chomp
+target_commit_id = `curl http://0.0.0.0:9000/resolve_git_commit/#{target}`.chomp
 Apache.errlogger Apache::APLOG_NOTICE, \
   "target: #{target}, target_commit_id: #{target_commit_id}"
 # There is the target commit in repository or having not been initialized as


### PR DESCRIPTION
I fixed the issue #76 .
`git rev-parse` failed when the remote branch not checkout to local.
For example, when accessing `development.pool.dev`, in builder server, `remotes/origin/development` branch exists correctly but `development` branch doesn't exist. So builder fail to execute `git rev-parse development` inside, then builder builds nothing.

To fix this bug, I added some recovery process to `git rev-parse` flow.
- If it's fail to find commit-ref specified by subdomain with executing `git rev-parse`, try to search the branch in 'remotes/_/_' branches again.
- `git rev-parse` was called in `hook.rb`, but it was hard to fix because written it's written in mruby, so I moved this function to `build_server`. Now, the proxy handler get commit-id by communicating with `build server` via `http://0.0.0.0:9000/resolve_git_commit/<commit-ref>`.
