### PR TITLE
Change to fetch everytime

### DIFF
--- a/docker/pool/builder/lib/builder.rb
+++ b/docker/pool/builder/lib/builder.rb
@@ -17,6 +17,7 @@ module Builder
     git_base = opts[:git_base] || Git.open("#{WORK_DIR}/#{APP_REPO_DIR_NAME}")
 
     begin
+      git_base.fetch
       commit_id = git_base.revparse(git_commit_specifier)
     rescue => e
       if e.message =~ /unknown revision or path not in the working tree/


### PR DESCRIPTION
For now, Builder does not fetch origin after the repository was cloned at first time.
This change does `fetch` command before `rev-parse` so that if branch name was given, pool can return the latest commit related to branch name everytime.
