### PR TITLE
Use docker-api gem instead using external command

### DIFF
--- a/docker/pool/builder/lib/builder/docker_handler.rb
+++ b/docker/pool/builder/lib/builder/docker_handler.rb
@@ -21,10 +21,11 @@ module Builder
         commit_id = $1
         begin
           res.status = 200
-          addr = Docker.find_container_by_commit_id(commit_id)
-          if addr
+          container = Docker.find_container_by_commit_id(commit_id)
+          if container
+            addr = "#{container[:ip]}:#{container[:port]}"
             res.content = JSON.generate({:status => 'success',
-                                        :addr => addr})
+                                         :addr => addr})
             @logger.info "found container_id: #{res.content}"
             return res.send_response
           end

--- a/docker/pool/builder/spec/features/build_server_spec.rb
+++ b/docker/pool/builder/spec/features/build_server_spec.rb
@@ -112,7 +112,7 @@ describe 'Builder', :system_test => true do
 
   def init_lisnter(git_commit_specifier)
     conn =  EM::EventSource.new("#{@test_addr}/#{git_commit_specifier}")
-    conn.inactivity_timeout = 120
+    conn.inactivity_timeout = 240
     return conn
   end
 end


### PR DESCRIPTION
#117 .

**docker/pool/builder/lib/builder.rb**

- Moved the part of control docker daemon to `docker.rb`
- `builder.rb` requires `Docker` module in `docker.rb` and call method `Docker.run`, `Docker.build`, `Docker.find_container_by_commit_id`.
- Docker build log is sent to logger initialized by `BuilderLogDevice`, setup runs at L61.

**docker/pool/builder/lib/builder/docker.rb**

- `Docker.build`: builds docker image. `build_from_dir` takes block which process output log. `output` is JSON format, send to logger arranged by its log structure.
- `Docker.run`: runs container from built docker image.
	- `PublishAllPort` corresponds to `-P` [option](https://docs.docker.com/reference/api/docker_remote_api_v1.16/#start-a-container) in `docker run` command.
- `format_container_data` formats the structure of docker container hash object to fit use case in `Builder`.
- `find_container_by_commit_id` and `run` method returns its hash object represents container information formatted by `format_container_data`.

**docker/pool/builder/lib/builder/docker_handler.rb**

- Return value of `find_container_by_commit_id` is changed, so changed `docker_handler` how to get the address from container hash object. 