### PR TITLE
builder: share build log

### DIFF
--- a/docker/pool/builder/lib/builder/builder_log_device.rb
+++ b/docker/pool/builder/lib/builder/builder_log_device.rb
@@ -1,5 +1,30 @@
+require 'singleton'
 # LogDevice to write log to a file and send it through EM:WebSocket at once.
 module Builder
+  class BuilderLogDevicePool
+    include Singleton
+
+    def initialize
+      @devices = {}
+      @m = Mutex.new
+    end
+
+    def find_or_create_device(git_commit_id, res, log_file)
+      @m.synchronize do 
+        if @devices[git_commit_id]
+          @devices[git_commit_id].add_device(res)
+        else
+          @devices[git_commit_id] = BuilderLogDevice.new(res, "#{log_file}")
+        end
+        return @devices[git_commit_id]
+      end
+    end
+
+    def delete_device(git_commit_id)
+      @devices.reject!{|k| k == git_commit_id}
+    end
+  end
+
   class BuilderLogDevice
     @logfile = nil
     @res = nil
@@ -11,20 +36,37 @@ module Builder
     def initialize(res, logfile = nil)
       raise RuntimeError, 'Output objects are nil' if res.nil?
       @logfile = File.new(logfile, 'a') unless logfile.nil?
-      @res  = res
+      @responses = [res]
+      @m = Mutex.new
       self.write('BuilderLogDevice is initialized')
     end
 
     # write and send to client the log message
     def write(message)
-      @logfile.write(message) unless @logfile.nil?
-      @res.send_event("build_log", strip_control_chars(message))
+      @m.synchronize do
+        @logfile.write(message) unless @logfile.nil?
+        @responses.each{|res| res.send_event("build_log", strip_control_chars(message)) }
+      end
+    end
+
+    def notify_finished
+      @m.synchronize do
+        @responses.each{|res| res.send_event('build_finished', 'FINISHED') }
+      end
+    end
+
+    def add_device(res)
+      @m.synchronize do
+        @responses << res
+      end
     end
 
     # Close file object
     def close
-      @res.close_connection_after_writing
-      @logfile.close
+      @m.synchronize do
+        @responses.each{|res| res.close_connection_after_writing }
+        @logfile.close
+      end
     end
 
     def strip_control_chars(message)

--- a/docker/pool/builder/lib/builder/constants.rb
+++ b/docker/pool/builder/lib/builder/constants.rb
@@ -6,4 +6,5 @@ module Builder
   ID_LIST_FILE_NAME = "ids"
   REPOSITORY_CONF = "preview_target_repository"
   LOCK_DIR = '/var/lock/subsys/'
+  BUILD_LOCK_TIMEOUT = 60 * 15 # 15 minutes
 end


### PR DESCRIPTION
#26 , #90 , #120 .
When access the environment while building image in another session, also stream build logs to new session which is locked state until finish building image . 

To share build logs, made logdevice object shared with all session.
`BuilderLogDevicePool` keeps `BuilderLogDevice` object each git commit id.
And `BuilderLogDevice` has multiple `HttpResponse` object, attached when new eventsource session is created.

**docker/pool/builder/lib/builder/builder_log_device.rb**

- Added `BuilderLogDevicePool`: It's singleton object, shared by all `Builder` thread.
- `@devices` is a hash object: its key is `git_commit_id`, and value is `BuilderLogDevice`.
- Made `BuilderLogDevice` to have multiple `HttpResponse` object. now `BuilderLogDevice` can send build logs to multiple
  HTTP sessions. 

**docker/pool/builder/lib/builder.rb**

- When new `Builder` thread is created, try to use `BuilderLogDevice` object already created inside `BuilderLogDevicePool`.
- If they finds a already created `BuilderLogDevice`, `Builder` object add the its `HTTPResponse` to `BuilderLogDevice` through `BuilderLogDevicePool`. 

**docker/pool/builder/lib/builder/constants.rb**

- Added the timeout value how long `Builder` can receive logs and wait lock state during another process building the image.

**docker/pool/builder/spec/features/build_server_spec.rb**

- Fix test to check whether `Builder` supports sharing build log feature.