### PR TITLE
builder/git: reset to origin/HEAD before git-revparse

### DIFF
--- a/docker/pool/builder/lib/builder/git.rb
+++ b/docker/pool/builder/lib/builder/git.rb
@@ -10,6 +10,7 @@ module Builder
 
       begin
         git_base.fetch
+        git_base.reset_hard('origin/HEAD')
         commit_id = git_base.revparse(git_commit_specifier)
       rescue => e
         if e.message =~ /unknown revision or path not in the working tree/


### PR DESCRIPTION
If preview target refs are exist in the local repository checked out automatically when `git clone` is executed, for example, 'master', `commit_id = git_base.revparse("master")` in `resolve_git_commit_id` always returns old commit-id in local `master` branch, so that they cannot get the latest commit hash id even if "git_base.fetch" update `origin/master` ref.