### PR TITLE
Remove useless port parameter

### DIFF
--- a/scripts/init_host_server
+++ b/scripts/init_host_server
@@ -76,5 +76,5 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock \
               --env PREVIEW_REPOSITORY_URL=${PREVIEW_REPOSITORY_URL} \
               --env POOL_BASE_DOMAIN=${POOL_BASE_DOMAIN} \
               --env GITHUB_BOT=${GITHUB_BOT} \
-              --name pool -p 80:80 -p 8080:8080 pool-server
+              --name pool -p 80:80 pool-server
 hostname pool


### PR DESCRIPTION
As we don't use websocket between client and pool server anymore,
port 8080 is not needed to be open.