### PR TITLE
#134 Support os which have systemd

### DIFF
--- a/scripts/init_host_server
+++ b/scripts/init_host_server
@@ -35,8 +35,8 @@ mkdir -p /opt/pool/bin
 export POOL_BIN_PATH=/opt/pool/bin
 export PATH=${POOL_BIN_PATH}:$PATH:/usr/local/bin
 
-if [[ -f /etc/os-release ]] && [[ $(cat /etc/os-release | grep "NAME=CoreOS") ]]; then
-    echo "CoreOS detected. Updating to latest docker.."
+if [ $(which systemctl) ]; then
+    echo "systemd detected. Updating to latest docker.."
     systemctl stop docker
     wget -q https://get.docker.com/builds/Linux/x86_64/docker-latest -O ${POOL_BIN_PATH}/docker
     chmod +x ${POOL_BIN_PATH}/docker
@@ -50,6 +50,13 @@ EOF
     systemctl daemon-reload
     systemctl enable docker
     systemctl start docker
+else
+    echo "NOTICE:"
+    echo "This system does not have systemd and docker was not updated
+    automatically."
+    echo "pool container uses the latest docker."
+    echo "If docker on host is not the latest version, pool may not work
+    correctly as it can not communicate between host and containers."
 fi
 
 # load cache images on local if it exists (for speed to build vagrant)

--- a/scripts/init_host_server
+++ b/scripts/init_host_server
@@ -40,7 +40,7 @@ if [ $(which systemctl) ]; then
     systemctl stop docker
     wget -q https://get.docker.com/builds/Linux/x86_64/docker-latest -O ${POOL_BIN_PATH}/docker
     chmod +x ${POOL_BIN_PATH}/docker
-    cat << EOF > /etc/systemd/system/docker.service 
+    cat << EOF > /etc/systemd/system/docker.service
 .include /usr/lib/systemd/system/docker.service
 
 [Service]


### PR DESCRIPTION
#134 
I changed `scripts/init_host_server` to update docker to the latest version if operation system has `systemd`; not only if operation system is CoreOS.

`init_host_server` is made for creating Vagrant environment at first but it can be used to set up host machine.
I tested it on both Vagrant and EC2 image; `CentOS 7 x86_64 (2014_09_29) EBS HVM-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-d2a117ba.2 (ami-89634988)` which has `systemd` as default.