### PR TITLE
Refactor hook.rb to use `Apache.return` correctly

### DIFF
--- a/docker/pool/handlers/hook.rb
+++ b/docker/pool/handlers/hook.rb
@@ -9,11 +9,11 @@ def return_build_screen
   r = Apache::Request.new
   Apache.errlogger Apache::APLOG_NOTICE, \
     "#{r.uri}, #{r.path_info}, #{r.args}, #{r.protocol}, #{r.the_request}"
-  
+
   doc_root = "/app/handlers/resources/build-screen/"
 
   if r.uri =~ /^\/(styles|scripts|images)\//
-    r.filename = doc_root + r.uri 
+    r.filename = doc_root + r.uri
   elsif r.uri =~ /^\/build/
     r.reverse_proxy "http://localhost:9001" + r.uri
   else
@@ -33,7 +33,7 @@ target = hin["Host"].split(".")[0]
 
 # To request and control git repository inside pool, init the api client
 # Git repository handler(GitHandler) listens on "http://0.0.0.0:9000"
-git_api = WebAPI.new("http://0.0.0.0:9000") 
+git_api = WebAPI.new("http://0.0.0.0:9000")
 
 # Initialize preview target git repository via githandler api.
 # After requesting to initialize git repository via '/init_repo',
@@ -41,27 +41,32 @@ git_api = WebAPI.new("http://0.0.0.0:9000")
 # Apache returns Bad request.
 git_api.get("/init_repo")
 
-Apache::return(Apache::HTTP_BAD_REQUEST) unless FileTest.exist?(APP_REPO_DIR)
-
-# Resolve actual git commit ref by target name got from subdomain via git handler api
-res = git_api.get("/resolve_git_commit/#{target}")
-target_commit_id = res.body
-Apache.errlogger Apache::APLOG_NOTICE, \
-  "target: #{target}, target_commit_id: #{target_commit_id}"
-# There is the target commit in repository or having not been initialized as
-# Git repository, return bad request response
-Apache::return(Apache::HTTP_BAD_REQUEST) unless res.code == "200"
-
-docker_api = WebAPI.new("http://0.0.0.0:9002")
-
-container_addr = docker_api.get("/containers/#{target_commit_id}").body
-matched_container = JSON.parse(container_addr)
-
-if matched_container["status"] != "success"
-  return_build_screen
+unless FileTest.exist?(APP_REPO_DIR)
+  Apache::return(Apache::HTTP_BAD_REQUEST)
 else
-  # Forward to container
-  r = Apache::Request.new
-  r.reverse_proxy "http://#{matched_container["addr"]}" + r.uri
-  Apache::return(Apache::OK)
+  # Resolve actual git commit ref by target name got from subdomain via git
+  # handler api
+  res = git_api.get("/resolve_git_commit/#{target}")
+  target_commit_id = res.body
+  Apache.errlogger Apache::APLOG_NOTICE, \
+    "target: #{target}, target_commit_id: #{target_commit_id}"
+  # There is the target commit in repository or having not been initialized as
+  # Git repository, return bad request response
+  unless res.code == "200"
+    Apache::return(Apache::HTTP_BAD_REQUEST)
+  else
+    docker_api = WebAPI.new("http://0.0.0.0:9002")
+
+    container_addr = docker_api.get("/containers/#{target_commit_id}").body
+    matched_container = JSON.parse(container_addr)
+
+    if matched_container["status"] != "success"
+      return_build_screen
+    else
+      # Forward to container
+      r = Apache::Request.new
+      r.reverse_proxy "http://#{matched_container["addr"]}" + r.uri
+      Apache::return(Apache::OK)
+    end
+  end
 end


### PR DESCRIPTION
`Apache.return` can't return from Ruby code. This method only set HTTP status code.