### PR TITLE
Fix bug; pool return wrong status code when don't found commit-id

### DIFF
--- a/docker/pool/builder/lib/builder/build_handler.rb
+++ b/docker/pool/builder/lib/builder/build_handler.rb
@@ -7,7 +7,7 @@ module EventMachine
   class HttpResponse
     attr_accessor :sse
     def fixup_headers
-      if @content
+      if @content && @content.is_a?(String)
         @headers["Content-Length"] = @content.bytesize
       elsif @chunks
         @headers["Transfer-Encoding"] = "chunked"


### PR DESCRIPTION
pool return 404 instead of assumed 400 (Bad Request) when can't find commit-id
or branch name because `.byteseze` method raise error when `@content` is
raise object.