### PR TITLE
fix bad permission for .ssh/config

### DIFF
--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -65,11 +65,11 @@ RUN touch /app/images/ids
 
 # Add private key directory to clone repository
 RUN mkdir -p /root/.ssh
-RUN chmod 600 /root/.ssh
 RUN mkdir -p /var/www/.ssh
 ADD keys /app/keys
 ADD /provisioning/ssh_config /var/www/.ssh/config
 ADD /provisioning/ssh_config /root/.ssh/config
+RUN chmod 600 /root/.ssh/config
 RUN chown -R apache. /var/www/.ssh
 
 # Add config files

--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -65,6 +65,7 @@ RUN touch /app/images/ids
 
 # Add private key directory to clone repository
 RUN mkdir -p /root/.ssh
+RUN chmod 600 /root/.ssh
 RUN mkdir -p /var/www/.ssh
 ADD keys /app/keys
 ADD /provisioning/ssh_config /var/www/.ssh/config


### PR DESCRIPTION
### Summary
The problem is that code is not cloned from private repository due to an incorrect permission for /root/.ssh/config. Therefore I changed permission to 600.

Error I joined a pool-server container using docker exec and tried to clone repo. 
```
root@f4bd2f9bb4d6 .ssh]# ls -la
total 16
drwxr-xr-x  2 root root 4096 Jan 27 09:05 .
dr-xr-x--- 13 root root 4096 Jan 27 09:05 ..
-rw-rw-r--  1 root root   46 Jan 26 22:13 config

Initialized empty Git repository in /tmp/test/
Bad owner or permissions on /root/.ssh/config
```

I am using Github private and trying to build preview environment by pool. I put id_rsa in $HOME/docker/pool/keys. The key was copied but code is not fetched from my repository due to the bad permission of .ssh/config.
