### PR TITLE
add container name cache

### DIFF
--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -85,6 +85,26 @@ RUN usermod -G docker,pool apache
 RUN chgrp --recursive pool /app
 RUN chmod --recursive g+rwx /app
 
+RUN echo "install redis"
+RUN yum install -y wget
+RUN \
+  cd /tmp && \
+  wget http://download.redis.io/releases/redis-2.8.19.tar.gz && \
+  tar xvzf redis-2.8.19.tar.gz && \
+  cd redis-2.8.19 && \
+  make && \
+  make install && \
+  mkdir -p /etc/redis && \
+  cp -f redis.conf /etc/redis && \
+  cp -pi utils/redis_init_script /etc/init.d/redis && \
+  rm -rf /tmp/redis-2.8.19* && \
+  mkdir -p /opt/redis && \
+  sed -i 's/daemonize no/daemonize yes/g' /etc/redis/redis.conf && \
+  sed -i 's/dir \/data/dir \/opt\/redis/g' /etc/redis/redis.conf && \
+  sed -i 's/PIDFILE\=\/var\/run\/redis_\${REDISPORT}\.pid/PIDFILE\=\/var\/run\/redis\.pid/g' /etc/init.d/redis && \
+  sed -i 's/CONF\="\/etc\/redis\/\${REDISPORT}\.conf"/CONF\="\/etc\/redis\/redis\.conf"/g' /etc/init.d/redis
+RUN gem install redis
+
 # Set target preview repository
 ENV PREVIEW_REPOSITORY_URL https://github.com/mookjp/flaskapp.git
 ENV MAX_CONTAINERS 10

--- a/docker/pool/scripts/starter
+++ b/docker/pool/scripts/starter
@@ -24,6 +24,7 @@ echo ${POOL_BASE_DOMAIN} >> /etc/hosts
 
 chown root:docker /var/run/docker.sock && \
 chmod 775 /var/run/docker.sock && \
+/etc/init.d/redis start && \
 service crond start && \
 service httpd start && \
 supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
リクエストごとにgitのチェックとコンテナの存在チェックを行っているが、ページに含まれるcss、js、画像に対するリクエストが来た時でもチェックが行われてしまい、画面の表示に時間が結構かかります。

そこで、redisを使ってサブドメインに紐づくコンテナの情報をキャッシュさせることで、高速化を図りました。
長時間キャッシュしてしまうと、ブランチを指定した場合に新しいコミットが追加されていても、キャッシュにより反映されなくなってしまうため、10秒程度としています。