### PR TITLE
Implement caching to resolve git-commit-id

### DIFF
--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -88,6 +88,7 @@ RUN chmod --recursive g+rwx /app
 # Set target preview repository
 ENV PREVIEW_REPOSITORY_URL https://github.com/mookjp/flaskapp.git
 ENV MAX_CONTAINERS 10
+ENV GIT_COMMIT_ID_CACHE_EXPIRE 10
 ENV POOL_BASE_DOMAIN pool.dev
 ENV GITHUB_BOT false
 

--- a/docker/pool/builder/builder.gemspec
+++ b/docker/pool/builder/builder.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "docker-api"
   spec.add_runtime_dependency "octokit"
   spec.add_runtime_dependency "faraday-http-cache"
+  spec.add_runtime_dependency "activesupport"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "em-spec"

--- a/docker/pool/builder/lib/builder/config.rb
+++ b/docker/pool/builder/lib/builder/config.rb
@@ -8,11 +8,20 @@ module Builder
     @defaults = {
       :repository_conf  => File.join(WORK_DIR, REPOSITORY_CONF),
       :base_domain_file => File.join(WORK_DIR, 'base_domain'),
+      :git_commit_id_cache_expire => File.join(WORK_DIR, 'git_commit_id_cache_expire'),
       :config_yml_path  => File.join(WORK_DIR, '../config', 'config.yml'),
       :id_list_file_path => File.join(WORK_DIR, ID_LIST_FILE_NAME)
     }
 
     module_function 
+
+    def defaults
+      @defaults
+    end
+
+    def read_git_commit_id_cache_expire(git_commit_id_cache_expire = @defaults[:git_commit_id_cache_expire]) 
+      File.open(git_commit_id_cache_expire).gets.chomp
+    end
 
     def read_base_domain(base_domain_file = @defaults[:base_domain_file]) 
       File.open(base_domain_file).gets.chomp

--- a/docker/pool/builder/lib/builder/git/cache.rb
+++ b/docker/pool/builder/lib/builder/git/cache.rb
@@ -1,0 +1,20 @@
+require 'builder/constants'
+require 'builder/config'
+require 'active_support/cache'
+
+module Builder
+  module Git
+    class Cache
+      include Singleton
+
+      def initialize
+        @git_commit_id_cache_expire ||= Config.read_git_commit_id_cache_expire
+        @cache  = ActiveSupport::Cache::MemoryStore.new(expires_in: @git_commit_id_cache_expire)
+      end
+
+      def fetch(key, &block)
+        @cache.fetch(key, &block)
+      end
+    end
+  end
+end

--- a/docker/pool/builder/spec/builder/builder/git_handler_spec.rb
+++ b/docker/pool/builder/spec/builder/builder/git_handler_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'builder'
+require 'builder/constants'
 require 'builder/builder_log_device'
 require 'em-spec/rspec'
 require 'em-http'
@@ -17,12 +18,27 @@ describe 'git handler' do
     Dir.mkdir(@output_dir_path) if not FileTest.exist?(@output_dir_path)
     fixture_dir = File.join(@base_fixture_dir_path, 'app01')
 
+    module Builder
+      module Config
+        @defaults = {
+          :repository_conf  => File.join(WORK_DIR, REPOSITORY_CONF),
+          :base_domain_file => File.join(WORK_DIR, 'base_domain'),
+          :git_commit_id_cache_expire => File.join(WORK_DIR, 'git_commit_id_cache_expire'),
+          :config_yml_path  => File.join(WORK_DIR, '../config', 'config.yml'),
+          :id_list_file_path => File.join(WORK_DIR, ID_LIST_FILE_NAME)
+        }
+      end
+    end
+
     # create repository file
     fixture_repository_file_path =
         File.expand_path('preview_target_repository', fixture_dir)
     tmp_repository_file_path =
         File.expand_path('preview_target_repository', @output_dir_path)
     File.copy_stream(fixture_repository_file_path, tmp_repository_file_path)
+
+    git_commit_id_cache_expire_path = File.join(@output_dir_path, 'git_commit_id_cache_expire')
+    File.write(git_commit_id_cache_expire_path, 10)
   end
 
   after(:each) do

--- a/docker/pool/scripts/starter
+++ b/docker/pool/scripts/starter
@@ -18,6 +18,7 @@ fi
 echo -n ${PREVIEW_REPOSITORY_URL} > /app/images/preview_target_repository
 echo -n ${MAX_CONTAINERS} > /app/images/max_containers
 echo -n ${POOL_BASE_DOMAIN} > /app/images/base_domain
+echo -n ${GIT_COMMIT_ID_CACHE_EXPIRE} > /app/images/git_commit_id_cache_expire
 
 # setup hosts file
 echo ${POOL_BASE_DOMAIN} >> /etc/hosts


### PR DESCRIPTION
Related to PR #148 , I implement cache system for the performance problem about resolving git-comit-id.

**Implementation details:**

- *docker/pool/builder/lib/builder/git/cache.rb*
  - cache class(singleton). I used [ActiveSupport::Cache](http://apidock.com/rails/ActiveSupport/Cache/Store/fetch) to implement cache.
  - A cache expiration time is configurable with `GIT_COMMIT_ID_CACHE_EXPIRE` (seconds) environment variable.
- *docker/pool/builder/lib/builder/git_handler.rb*
  - This class uses cache class. if `resolve_git_commit_id` is called once, api returns from cache value during cache expiration time.

For example, this implovement make the rendering speed faster, such a web application contains many static contents (Try preview https://github.com/ainoya/docker_wordpress_nginx.git)