### PR TITLE
Fix inconvenience found while accessing to private repo

### DIFF
--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -70,6 +70,8 @@ ADD keys /app/keys
 ADD /provisioning/ssh_config /var/www/.ssh/config
 ADD /provisioning/ssh_config /root/.ssh/config
 RUN chown -R apache. /var/www/.ssh
+RUN chmod 600 /var/www/.ssh/config /root/.ssh/config
+RUN chmod 700 /var/www/.ssh /root/.ssh
 
 # Add config files
 ADD config /app/config

--- a/docker/pool/builder/bin/build_server
+++ b/docker/pool/builder/bin/build_server
@@ -2,6 +2,7 @@
 # -*- mode: ruby -*-
 
 require 'builder'
+STDOUT.sync = true
 
 EM.run {
   # GET "http://0.0.0.0:9000/resolve_git_commit/origin/development",

--- a/docker/pool/handlers/hook.rb
+++ b/docker/pool/handlers/hook.rb
@@ -41,7 +41,7 @@ git_api = WebAPI.new("http://0.0.0.0:9000")
 # Apache returns Bad request.
 res = git_api.get("/init_repo")
 if res.code != "200"
-  Apache.errlogger(Apache::APLOG_WARNING, "git_api /init_repo returned #{result.code}: #{result.body}")
+  Apache.errlogger(Apache::APLOG_WARNING, "git_api /init_repo returned #{res.code}: #{res.body}")
   Apache::return(Apache::HTTP_BAD_REQUEST)
 elsif !FileTest.exist?(APP_REPO_DIR)
   Apache.errlogger(Apache::APLOG_WARNING, "#{APP_REPO_DIR} is not created")

--- a/docker/pool/handlers/hook.rb
+++ b/docker/pool/handlers/hook.rb
@@ -39,9 +39,12 @@ git_api = WebAPI.new("http://0.0.0.0:9000")
 # After requesting to initialize git repository via '/init_repo',
 # check if repository doesn't exist because of some error or fail,
 # Apache returns Bad request.
-git_api.get("/init_repo")
-
-unless FileTest.exist?(APP_REPO_DIR)
+res = git_api.get("/init_repo")
+if res.code != "200"
+  Apache.errlogger(Apache::APLOG_WARNING, "git_api /init_repo returned #{result.code}: #{result.body}")
+  Apache::return(Apache::HTTP_BAD_REQUEST)
+elsif !FileTest.exist?(APP_REPO_DIR)
+  Apache.errlogger(Apache::APLOG_WARNING, "#{APP_REPO_DIR} is not created")
   Apache::return(Apache::HTTP_BAD_REQUEST)
 else
   # Resolve actual git commit ref by target name got from subdomain via git


### PR DESCRIPTION
Here are several fixes i applied to my fork for productivity.
I appreciate if you take some of them, but feel free to reject if they do not fit :grinning:
See commit comments for details.

I still have a problems about `docker` gid.

My host has docker group and `docker.sock` owned by `root:docker, 0660`.
Starter script `chown root:docker /var/run/docker.sock` against mounted `docker.sock`, that changes owner gid of host's `docker.sock`.
To avoid this, I change container's docker gid to host's one with

```bash
${POOL_BIN_PATH}/docker-enter pool groupmod -g $(grep docker: /etc/group | awk -F ':' '{ print $3 }') docker
```

I prefer to include something like this to pool.
I could not find an elegant way. Any advice is appreciated.