### PR TITLE
Fix wercker file

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -13,8 +13,11 @@ build:
           sudo service docker start
           docker -v
     - script:
-        name: update apt-get
-        code: sudo apt-get update
+        name: update packages
+        code: |
+          sudo sed -i -E 's/http:\/\/.+\.archive.ubuntu.com/http:\/\/old-releases.ubuntu.com/g' /etc/apt/sources.list
+          sudo sed -i -E 's/security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+          sudo apt-get update
     - script:
         name: install ruby for slack notification
         code: sudo apt-get install -y ruby

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,6 +13,9 @@ build:
           sudo service docker start
           docker -v
     - script:
+        name: update apt-get
+        code: sudo apt-get update
+    - script:
         name: install ruby for slack notification
         code: sudo apt-get install -y ruby
     - script:


### PR DESCRIPTION
 `apt-get update` command failed because Ubuntu's packages was moved to **old-releases**.
I added commands to rewrite `sources.list` to see correct place.

FYI: If tihs changes is merged, wercker test will fail by another problem with test case. I will create another PR to fix test.