### PR TITLE
Add require to use pp

### DIFF
--- a/docker/pool/builder/spec/builder/builder/git_spec.rb
+++ b/docker/pool/builder/spec/builder/builder/git_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'builder'
 require 'builder/builder_log_device'
 require 'fileutils'
+require 'pp'
 
 describe '.resolve_commit_id' do
   before(:each) do


### PR DESCRIPTION
I'm not sure why `pp` package doesn't work on wercker but it needs to `require` this package now.
I'll follow if I found actual reason why this problem occurred.
